### PR TITLE
Fixed signup model to have necessary fields in request

### DIFF
--- a/lib/src/model/signup_models.dart
+++ b/lib/src/model/signup_models.dart
@@ -17,19 +17,26 @@ class SignUpRequest {
       this.appSecret});
 
   Map<String, dynamic> toJson() {
+    var fieldsJson = <String, dynamic>{
+      'FIRST_NAME': firstName,
+      'LAST_NAME': lastName,
+      'EMAIL': email,
+      'PASSWORD': password,
+    };
+    
     var json = <String, dynamic>{
-      'firstName': firstName,
-      'lastName': lastName,
-      'email': email,
-      'password': password,
+      'fields': fieldsJson,
       'recaptchaResponse': recaptchaResponse
     };
+
+    // Optional fields
     if (pkgName != null) {
       json['pkgName'] = pkgName;
     }
     if (appSecret != null) {
       json['appSecret'] = appSecret;
     }
+
     return json;
   }
 


### PR DESCRIPTION
Current Signup model is not valid for the new version of the Thingsboard. 

Needed data should be enclosed in `fields `key in the JSON.

This fix changes the Signup model `toJson `method to ensure that signup process still works. 